### PR TITLE
Store the entire history of the Merkle trees in the database.

### DIFF
--- a/dev-accounts.json
+++ b/dev-accounts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "ens": "cha0sg0d.eth",
+    "pubKey": "2e1869b4aa4611eff68043fb8bfecf9e58a6252cf3de6547167099a3124345c0372b2a0edc636444c0718b53c76da503e3619e82bb4f0e2e34cbc02a84ad18d3",
+    "address": "3ff4EcB0D7A01235dcCD9fc59B0d4969Cb011032"
+  },
+  {
+    "ens": "amirbolous.eth",
+    "pubKey": "3ba0d5397de63df8884014d446fd68318345f236cfe3f808ae879dedb471fdb2673e0be282cbf9a422333c36afa2b5e6dc815bbb40e9cd0dc7df5179759d1383",
+    "address": "926B47C42Ce6BC92242c080CF8fAFEd34a164017"
+  },
+  {
+    "ens": "jessewldn.eth",
+    "pubKey": "68c5810a40f71b05b3d7b3a9b32fda173fdaad989ab906a4e95d615c2f63951a33dcf5ddbc001f8e65a22856ed5680867bbcb857a170f554dabc51d27b2d6357",
+    "address": "e7925d190aea9279400cd9a005e33ceb9389cc2b"
+  },
+  {
+    "ens": "alanalevin.eth",
+    "pubKey": "0da283936e4d6ca37550c4d3276c8a3cfbe85b66a4ab6d0e9568d1170d8a8db313384ae9a0007bc8e791f645b09a7372bb9054d087ce3969536be51612476820",
+    "address": "26f35e0f8f3030907044ac0a43e72c1a17284137"
+  },
+  {
+    "ens": "arthaud.eth",
+    "pubKey": "2ea13bb3e1a31ff5415796710618cc65ff8a1fa76a58b99588b605a2664aed2dc27247956cee495a55facba49b3df223ef02dd459aa5080e246a2c0b232aafc4",
+    "address": "95ec169fa2EF1b85f55713d8A6c5d244E15B9fD7"
+  },
+  {
+    "ens": "timbeiko.eth",
+    "pubKey": "5fed4a89d5c669b6774bc2f771b78170581f2170e77ec5ab29058153b4d8220244776bc4357341179080bbac29a830a8eb65cb4b46bfdd978c490ec9d9ce194c",
+    "address": "10f5d45854e038071485ac9e402308cf80d2d2fe"
+  }
+]

--- a/packages/db/prisma/migrations/20230615135702_tree_many_to_many/migration.sql
+++ b/packages/db/prisma/migrations/20230615135702_tree_many_to_many/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - The primary key for the `Tree` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[type,root,blockHeight]` on the table `Tree` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "DoxedUpvote" DROP CONSTRAINT "DoxedUpvote_groupRoot_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Post" DROP CONSTRAINT "Post_groupRoot_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TreeNode" DROP CONSTRAINT "TreeNode_root_fkey";
+
+-- AlterTable
+ALTER TABLE "Tree" DROP CONSTRAINT "Tree_pkey";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tree_type_root_blockHeight_key" ON "Tree"("type", "root", "blockHeight");

--- a/packages/db/prisma/migrations/20230615140108_non_unique_tree_node/migration.sql
+++ b/packages/db/prisma/migrations/20230615140108_non_unique_tree_node/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[type,pubkey,root]` on the table `TreeNode` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "TreeNode_type_pubkey_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TreeNode_type_pubkey_root_key" ON "TreeNode"("type", "pubkey", "root");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -17,20 +17,18 @@ model TreeNode {
   path      String[]
   indices   String[]
   root      String
-  tree      Tree      @relation(fields: [root], references: [root])
   createdAt DateTime  @default(now())
 
-  @@unique([type, pubkey])
+  @@unique([type, pubkey, root])
 }
 
 model Tree {
-  root        String        @id
+  root        String
   type        GroupType
   blockHeight Int
-  createdAt   DateTime      @default(now())
-  Post        Post[]
-  DoxedUpvote DoxedUpvote[]
-  TreeNode    TreeNode[]
+  createdAt   DateTime  @default(now())
+
+  @@unique([type, root, blockHeight])
 }
 
 model CachedEOA {
@@ -75,7 +73,6 @@ model Post {
   upvotes           DoxedUpvote[]
   venue             String
   groupRoot         String
-  group             Tree              @relation(fields: [groupRoot], references: [root])
   timestamp         DateTime
   attestation       String
   userId            String // Nym or ETH address
@@ -92,7 +89,6 @@ model DoxedUpvote {
   post      Post     @relation(fields: [postId], references: [id])
   address   String
   groupRoot String
-  group     Tree     @relation(fields: [groupRoot], references: [root])
   sig       String
   timestamp DateTime
   createdAt DateTime @default(now())

--- a/packages/frontend/src/pages/api/v1/groups/latest.ts
+++ b/packages/frontend/src/pages/api/v1/groups/latest.ts
@@ -13,7 +13,7 @@ const handleGetLatestGroup = async (req: NextApiRequest, res: NextApiResponse) =
       type: GroupType.OneNoun,
     },
     orderBy: {
-      createdAt: 'desc',
+      blockHeight: 'desc',
     },
   });
 

--- a/packages/merkle_tree/package.json
+++ b/packages/merkle_tree/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "pnpm graphclient build",
     "writeTree": "pnpm ts-node ./src/writeTree.ts",
+    "writeTree:dev": "INCLUDE_DEV_ACCOUNTS=true pnpm ts-node ./src/writeTree.ts",
     "populateCache": "pnpm ts-node ./scripts/populateCache.ts"
   },
   "dependencies": {

--- a/packages/merkle_tree/src/writeTree.ts
+++ b/packages/merkle_tree/src/writeTree.ts
@@ -266,70 +266,80 @@ async function writeTree(blockHeight: number) {
   const anonSet2Root = `0x${anonSet2Tree.root().toString(16)}`;
 
   // Write only if the tree is new
-  if (!(await treeExists(anonSet1Root))) {
-    console.log("Creating new tree for set Noun = 1");
-    await prisma.tree.create({
-      data: {
+  console.log("Creating new tree for set Noun = 1");
+  await prisma.tree.upsert({
+    where: {
+      type_root_blockHeight: {
         type: GroupType.OneNoun,
         blockHeight,
         root: anonSet1Root
       }
-    });
+    },
+    update: {
+      type: GroupType.OneNoun,
+      blockHeight,
+      root: anonSet1Root
+    },
+    create: {
+      type: GroupType.OneNoun,
+      blockHeight,
+      root: anonSet1Root
+    }
+  });
 
-    await prisma.treeNode.deleteMany({
-      where: {
-        type: GroupType.OneNoun
-      }
-    });
-
-    await prisma.treeNode.createMany({
-      data: anonSet1.map((account, i) => {
-        const index = anonSet1Tree.indexOf(anonSet1PubKeyHashes[i]);
-        const merkleProof = anonSet1Tree.createProof(index);
-        return {
-          address: account.address,
-          pubkey: account.pubKey,
-          path: merkleProof.siblings.map(s => BigInt(s[0]).toString(16)),
-          indices: merkleProof.pathIndices.map(i => i.toString()),
-          type: GroupType.OneNoun,
-          root: anonSet1Root
-        };
-      })
-    });
-  }
+  await prisma.treeNode.createMany({
+    data: anonSet1.map((account, i) => {
+      const index = anonSet1Tree.indexOf(anonSet1PubKeyHashes[i]);
+      const merkleProof = anonSet1Tree.createProof(index);
+      return {
+        address: account.address,
+        pubkey: account.pubKey,
+        path: merkleProof.siblings.map(s => BigInt(s[0]).toString(16)),
+        indices: merkleProof.pathIndices.map(i => i.toString()),
+        type: GroupType.OneNoun,
+        root: anonSet1Root
+      };
+    }),
+    skipDuplicates: true
+  });
 
   // Write only if the tree is new
-  if (!(await treeExists(anonSet2Root))) {
-    console.log("Creating new tree for set Noun > 1");
-    await prisma.tree.create({
-      data: {
+  console.log("Creating new tree for set Noun > 1");
+  await prisma.tree.upsert({
+    where: {
+      type_root_blockHeight: {
         type: GroupType.ManyNouns,
         blockHeight,
         root: anonSet2Root
       }
-    });
+    },
+    update: {
+      type: GroupType.ManyNouns,
+      blockHeight,
+      root: anonSet2Root
+    },
+    create: {
+      type: GroupType.ManyNouns,
+      blockHeight,
+      root: anonSet2Root
+    }
+  });
 
-    await prisma.treeNode.deleteMany({
-      where: {
-        type: GroupType.ManyNouns
-      }
-    });
-
-    await prisma.treeNode.createMany({
-      data: anonSet2.map((account, i) => {
-        const index = anonSet2Tree.indexOf(anonSet2PubKeyHashes[i]);
-        const merkleProof = anonSet2Tree.createProof(index);
-        return {
-          address: account.address,
-          pubkey: account.pubKey,
-          path: merkleProof.siblings.map(s => BigInt(s[0]).toString(16)),
-          indices: merkleProof.pathIndices.map(i => i.toString()),
-          type: GroupType.ManyNouns,
-          root: anonSet2Root
-        };
-      })
-    });
-  }
+  await prisma.treeNode.createMany({
+    data: anonSet2.map((account, i) => {
+      const index = anonSet2Tree.indexOf(anonSet2PubKeyHashes[i]);
+      const merkleProof = anonSet2Tree.createProof(index);
+      return {
+        address: account.address,
+        pubkey: account.pubKey,
+        path: merkleProof.siblings.map(s => BigInt(s[0]).toString(16)),
+        indices: merkleProof.pathIndices.map(i => i.toString()),
+        type: GroupType.ManyNouns,
+        root: anonSet2Root
+      };
+    }),
+    skipDuplicates: true
+  });
 
   console.log(
     `Noun = 1 set size ${anonSet1.length}, ${numNoPubKeySet1} missing public keys`

--- a/packages/merkle_tree/tsconfig.json
+++ b/packages/merkle_tree/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "exclude": [
-    "./jest.config.js",
-  ],
+  "exclude": ["./jest.config.js"],
   "compilerOptions": {
+    "resolveJsonModule": true,
     /* Visit https://aka.ms/tsconfig to read more about this file */
-    "outDir": "./build",                
+    "outDir": "./build",
 
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
@@ -15,7 +14,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -29,7 +28,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -81,12 +80,12 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -108,6 +107,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }

--- a/packages/test_data/scripts/populateTestData.ts
+++ b/packages/test_data/scripts/populateTestData.ts
@@ -341,7 +341,6 @@ const populateTestData = async () => {
   // ##############################
   log('Saving to database...');
 
-  // Save the dummy tree to the database
   const treeExists = await prisma.tree.findFirst({
     where: {
       root: treeRootHex,
@@ -369,10 +368,6 @@ const populateTestData = async () => {
   await prisma.doxedUpvote.createMany({
     data: upvotes,
   });
-
-  // Only the tree nodes of a single tree can exist in our database,
-  // so we delete all existing trees nodes to store a new set of tree nodes.
-  await prisma.treeNode.deleteMany({});
 
   const treeNodes = [
     ...PRIV_KEYS.map((privKey, i) => {
@@ -416,6 +411,7 @@ const populateTestData = async () => {
 
   await prisma.treeNode.createMany({
     data: treeNodes,
+    skipDuplicates: true,
   });
 
   log('...done!\n\n');

--- a/packages/test_data/scripts/populateTestData.ts
+++ b/packages/test_data/scripts/populateTestData.ts
@@ -38,6 +38,7 @@ import {
 import { Poseidon, Tree } from '@personaelabs/spartan-ecdsa';
 import * as fs from 'fs';
 import csvParser from 'csv-parser';
+import DEV_ACCOUNTS from '../../../dev-accounts.json';
 
 type CachedEOA = {
   address: string;
@@ -83,25 +84,12 @@ const log = (msg: string) => {
   process.stdout.write(`${msg}`);
 };
 
-// personaelabs.eth and dantehrani.eth are included in the cached nouners list
-const DEV_PUBKEYS = [
-  // cha0sg0d.eth
-  '2e1869b4aa4611eff68043fb8bfecf9e58a6252cf3de6547167099a3124345c0372b2a0edc636444c0718b53c76da503e3619e82bb4f0e2e34cbc02a84ad18d3',
-  // amirbolous.eth
-  '3ba0d5397de63df8884014d446fd68318345f236cfe3f808ae879dedb471fdb2673e0be282cbf9a422333c36afa2b5e6dc815bbb40e9cd0dc7df5179759d1383',
-].map((pubKey) => Buffer.from(pubKey, 'hex'));
-
-const DEV_ADDRESSES = [
-  // cha0sg0d.eth
-  '3ff4EcB0D7A01235dcCD9fc59B0d4969Cb011032',
-  // amirbolous.eth
-  '926B47C42Ce6BC92242c080CF8fAFEd34a164017',
-].map((address) => address.toLowerCase());
+const DEV_PUBKEYS = DEV_ACCOUNTS.map((account) => Buffer.from(account.pubKey, 'hex'));
 
 // Sanity check
-for (let i = 0; i < DEV_PUBKEYS.length; i++) {
+for (let i = 0; i < DEV_ACCOUNTS.length; i++) {
+  const address = DEV_ACCOUNTS[i].address.toLowerCase();
   const pubKey = DEV_PUBKEYS[i];
-  const address = DEV_ADDRESSES[i];
   if (pubToAddress(pubKey).toString('hex') !== address) {
     throw new Error(`Public key ${pubKey.toString('hex')} doesn't match the address ${address}`);
   }

--- a/packages/test_data/tsconfig.json
+++ b/packages/test_data/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "exclude": ["./jest.config.js"],
   "compilerOptions": {
+    "resolveJsonModule": true,
     /* Visit https://aka.ms/tsconfig to read more about this file */
     "outDir": "./build",
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,12 +1,11 @@
-previewsEnabled: true
 services:
   - type: cron
     name: nouns250-merkle-cron
-    plan: starter
-    previewPlan: starter
+    plan: standard
     env: node
     region: oregon
     rootDir: ./
+    branch: main
     schedule: "0 * * * *"
     buildCommand: ./scripts/setup_merkle_cron.sh
     startCommand: pnpm -F merkle_tree run writeTree
@@ -20,9 +19,34 @@ services:
           name: nouns250
           property: connectionString
       - fromGroup: nouns250
+  - type: cron
+    name: nouns250-merkle-cron-staging
+    plan: standard
+    env: node
+    region: oregon
+    rootDir: ./
+    branch: dev
+    schedule: "0 * * * *"
+    buildCommand: ./scripts/setup_merkle_cron.sh
+    startCommand: pnpm -F merkle_tree run writeTree:dev
+    buildFilter:
+      paths:
+      - packages/merkle_tree/**
+      - packages/db/**
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: nouns250-staging
+          property: connectionString
+      - fromGroup: nouns250-staging
 
 databases:
   - name: nouns250
+    databaseName: nym
+    region: oregon
+    plan: pro
+    postgresMajorVersion: 15
+  - name: nouns250-staging
     databaseName: nym
     region: oregon
     plan: starter


### PR DESCRIPTION
- Store the entire history of the nouner Merkle tree in the database.
- We still only allow generating proofs with the latest set, but as we want to allow generating proofs with a static root after launch, making the necessary db changes before launch to make the transition easier.
- Make it easier to add dev accounts/beta testers. (just add them to [dev-accounts.json](https://github.com/personaelabs/nym/blob/dan/render-cleanup/dev-accounts.json))
- Remove Render preview environments as we're not using them.

Testing this in local is a little tedious (you'll need to set alchemy/etherscan API keys) so I think we can merge and see if it works (confirmed that it works in my env)  but lmk if you still wanna test before merging!

The main thing is that I wanna let you know I'm making the above changes!