### PR TITLE
Allow replies in public posts API

### DIFF
--- a/packages/frontend/public/api-doc.yml
+++ b/packages/frontend/public/api-doc.yml
@@ -32,6 +32,11 @@ paths:
             enum:
               - timestamp
               - upvotes
+        - name: includeReplies
+          in: query
+          required: false
+          schema:
+            type: boolean
       responses:
         '200':
           description: OK

--- a/packages/frontend/public/api-doc.yml
+++ b/packages/frontend/public/api-doc.yml
@@ -14,16 +14,26 @@ paths:
       description: Get posts
       operationId: getPosts
       parameters:
-        - name: offset
+        - name: skip
           in: query
           required: false
           schema:
             type: number
-        - name: limit
+        - name: take
           in: query
           required: false
           schema:
             type: number
+        - name: startTime
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: endTime
+          in: query
+          required: false
+          schema:
+            type: string
         - name: sort
           in: query
           required: false

--- a/packages/frontend/public/api-doc.yml
+++ b/packages/frontend/public/api-doc.yml
@@ -29,11 +29,13 @@ paths:
           required: false
           schema:
             type: string
+          description: Timestamp in milliseconds
         - name: endTime
           in: query
           required: false
           schema:
             type: string
+          description: Timestamp in milliseconds
         - name: sort
           in: query
           required: false

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -1,7 +1,7 @@
 import { PostPreview } from '@/components/post/PostPreview';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { IPostPreview } from '@/types/api';
+import { IPostPreview, PostsQuery } from '@/types/api';
 import Spinner from './global/Spinner';
 import { MainButton } from './MainButton';
 import { Fragment, useContext, useState } from 'react';
@@ -22,13 +22,15 @@ import { useAccount } from 'wagmi';
 
 const PER_FETCH = 20;
 const getPosts = async ({ pageParam = 0 }: { pageParam?: number }, filter: String) => {
+  const params: PostsQuery = {
+    skip: pageParam,
+    take: PER_FETCH,
+    sort: filter.toString(),
+    rootOnly: true,
+  };
   const data = (
     await axios.get<IPostPreview[]>('/api/v1/posts', {
-      params: {
-        skip: pageParam,
-        take: PER_FETCH,
-        sort: filter,
-      },
+      params,
     })
   ).data;
 

--- a/packages/frontend/src/components/Posts.tsx
+++ b/packages/frontend/src/components/Posts.tsx
@@ -25,8 +25,8 @@ const getPosts = async ({ pageParam = 0 }: { pageParam?: number }, filter: Strin
   const data = (
     await axios.get<IPostPreview[]>('/api/v1/posts', {
       params: {
-        offset: pageParam,
-        limit: PER_FETCH,
+        skip: pageParam,
+        take: PER_FETCH,
         sort: filter,
       },
     })

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -46,8 +46,11 @@ const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPre
   const skip = req.query.offset ? parseInt(req.query.offset as string) : 0;
   const take = req.query.limit ? parseInt(req.query.limit as string) : 10;
   const sort = req.query.sort ? (req.query.sort as string) : 'timestamp'; // 'upvotes' or 'timestamp'. Default is 'timestamp'.
+  const includeReplies = req.query.includeReplies
+    ? (req.query.includeReplies + '').toLowerCase() === 'true'
+    : false;
 
-  const posts = await selectAndCleanPosts({ skip, take, sort });
+  const posts = await selectAndCleanPosts({ skip, take, sort, includeReplies });
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -47,7 +47,7 @@ const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPre
   const take = req.query.limit ? parseInt(req.query.limit as string) : 10;
   const sort = req.query.sort ? (req.query.sort as string) : 'timestamp'; // 'upvotes' or 'timestamp'. Default is 'timestamp'.
 
-  const posts = await selectAndCleanPosts(undefined, skip, take, sort);
+  const posts = await selectAndCleanPosts({ skip, take, sort });
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -40,22 +40,20 @@ const verifyRoot = async (root: string): Promise<boolean> =>
     : false;
 
 const cleanQuery = (query: RawPostsQuery): PostsQuery => {
-  const skip = query.skip ? parseInt(query.skip as string) : 0;
-  const take = query.take ? parseInt(query.take as string) : 10;
-  const sort = query.sort ? (query.sort as string) : 'timestamp'; // 'upvotes' or 'timestamp'. Default is 'timestamp'.
+  const skip = query.skip ? parseInt(query.skip) : 0;
+  const take = query.take ? parseInt(query.take) : 10;
+  const sort = query.sort ? query.sort : 'timestamp'; // 'upvotes' or 'timestamp'. Default is 'timestamp'.
   const includeReplies = query.includeReplies
     ? (query.includeReplies + '').toLowerCase() === 'true'
     : false;
-  const startTime = query.startTime;
-  const endTime = query.endTime;
-
+  const startTime = query.startTime ? parseInt(query.startTime) : undefined;
+  const endTime = query.endTime ? parseInt(query.endTime) : undefined;
   return { skip, take, sort, includeReplies, startTime, endTime };
 };
 
 // Return posts as specified by the query parameters
 const handleGetPosts = async (req: NextApiRequest, res: NextApiResponse<IPostPreview[]>) => {
   const query = cleanQuery(req.query as RawPostsQuery);
-
   const posts = await selectAndCleanPosts(query);
   res.send(posts);
 };

--- a/packages/frontend/src/pages/api/v1/posts.ts
+++ b/packages/frontend/src/pages/api/v1/posts.ts
@@ -43,12 +43,10 @@ const cleanQuery = (query: RawPostsQuery): PostsQuery => {
   const skip = query.skip ? parseInt(query.skip) : 0;
   const take = query.take ? parseInt(query.take) : 10;
   const sort = query.sort ? query.sort : 'timestamp'; // 'upvotes' or 'timestamp'. Default is 'timestamp'.
-  const includeReplies = query.includeReplies
-    ? (query.includeReplies + '').toLowerCase() === 'true'
-    : false;
+  const rootOnly = query.rootOnly ? query.rootOnly.toLowerCase() === 'true' : false;
   const startTime = query.startTime ? parseInt(query.startTime) : undefined;
   const endTime = query.endTime ? parseInt(query.endTime) : undefined;
-  return { skip, take, sort, includeReplies, startTime, endTime };
+  return { skip, take, sort, rootOnly, startTime, endTime };
 };
 
 // Return posts as specified by the query parameters

--- a/packages/frontend/src/pages/api/v1/users/[userId]/posts.ts
+++ b/packages/frontend/src/pages/api/v1/users/[userId]/posts.ts
@@ -20,7 +20,7 @@ const handleGetUserPosts = async (
     return;
   }
 
-  const posts = await selectAndCleanPosts(userId, skip, take);
+  const posts = await selectAndCleanPosts({ userId, skip, take });
   res.send(posts);
 };
 

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -103,7 +103,7 @@ const buildWhere = (query: PostsQuery) => {
     const isNym = !isAddress(query.userId);
     where.userId = isNym ? query.userId : query.userId.toLowerCase();
   }
-  if (!query.includeReplies) {
+  if (query.rootOnly) {
     where.rootId = null;
   }
   // Allows for optional args on start and end time

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -106,11 +106,11 @@ const buildWhere = (query: PostsQuery) => {
   if (!query.includeReplies) {
     where.rootId = null;
   }
-  if (query.startTime && query.endTime) {
-    where.timestamp = {
-      gte: new Date(query.startTime),
-      lte: new Date(query.endTime),
-    };
+  // Allows for optional args on start and end time
+  if (query.startTime || query.endTime) {
+    where.timestamp = {};
+    if (query.startTime) where.timestamp.gte = new Date(query.startTime);
+    if (query.endTime) where.timestamp.lte = new Date(query.endTime);
   }
 
   return where;

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -95,22 +95,29 @@ export const getRootFromParent = async (parentId: string): Promise<string | null
   return rootId;
 };
 
-export const selectAndCleanPosts = async (
-  userId?: string,
-  skip?: number,
-  take?: number,
-  sort?: string,
-) => {
-  const isNym = userId && !isAddress(userId);
+// object defining all 'feed-type' post queries a frontend might make
+export type PostsQuery = {
+  userId?: string;
+  skip?: number;
+  take?: number;
+  sort?: string;
+};
+
+export const selectAndCleanPosts = async (query: PostsQuery) => {
+  const isNym = query.userId && !isAddress(query.userId);
+
   // Determines whether we are searching for a user's posts or all root posts.
-  const where = userId ? { userId: isNym ? userId : userId.toLowerCase() } : { rootId: null };
+  const where = query.userId
+    ? { userId: isNym ? query.userId : query.userId.toLowerCase() }
+    : { rootId: null };
+
   const postsRaw = await prisma.post.findMany({
     select: postPreviewSelect,
     where,
-    skip,
-    take,
+    skip: query.skip,
+    take: query.take,
     orderBy:
-      sort === 'upvotes'
+      query.sort === 'upvotes'
         ? [
             { descendants: { _count: 'desc' } },
             { root: { descendants: { _count: 'desc' } } },

--- a/packages/frontend/src/pages/api/v1/utils.ts
+++ b/packages/frontend/src/pages/api/v1/utils.ts
@@ -108,8 +108,8 @@ const buildWhere = (query: PostsQuery) => {
   }
   if (query.startTime && query.endTime) {
     where.timestamp = {
-      gte: query.startTime,
-      lte: query.endTime,
+      gte: new Date(query.startTime),
+      lte: new Date(query.endTime),
     };
   }
 

--- a/packages/frontend/types/api/index.ts
+++ b/packages/frontend/types/api/index.ts
@@ -3,3 +3,4 @@ export * from './postPreviewSelect';
 export * from './userUpvotesSelect';
 export * from './users';
 export * from './notifications';
+export * from './queries';

--- a/packages/frontend/types/api/queries.ts
+++ b/packages/frontend/types/api/queries.ts
@@ -14,7 +14,7 @@ export type PostsQuery = {
   skip?: number;
   take?: number;
   sort?: string;
-  startTime?: string;
-  endTime?: string;
+  startTime?: number;
+  endTime?: number;
   includeReplies?: boolean;
 };

--- a/packages/frontend/types/api/queries.ts
+++ b/packages/frontend/types/api/queries.ts
@@ -6,7 +6,7 @@ export type RawPostsQuery = {
   sort?: string;
   startTime?: string;
   endTime?: string;
-  includeReplies?: string;
+  rootOnly?: string;
 };
 
 export type PostsQuery = {
@@ -16,5 +16,5 @@ export type PostsQuery = {
   sort?: string;
   startTime?: number;
   endTime?: number;
-  includeReplies?: boolean;
+  rootOnly?: boolean;
 };

--- a/packages/frontend/types/api/queries.ts
+++ b/packages/frontend/types/api/queries.ts
@@ -1,0 +1,20 @@
+// object defining all 'feed-type' post queries a frontend might make
+export type RawPostsQuery = {
+  userId?: string;
+  skip?: string;
+  take?: string;
+  sort?: string;
+  startTime?: string;
+  endTime?: string;
+  includeReplies?: string;
+};
+
+export type PostsQuery = {
+  userId?: string;
+  skip?: number;
+  take?: number;
+  sort?: string;
+  startTime?: string;
+  endTime?: string;
+  includeReplies?: boolean;
+};


### PR DESCRIPTION
After discussions with @cha0sg0d and joel from nerman, realized we need our public /posts/ API to serve posts+replies. This PR adds that and refactors the query logic in `selectAndCleanPosts` a bit

Closes #208 

The new API is as follows:

- Users can submit a timestamp for startTime AND OR endTime. If startTime exists, we get posts after or equal to that time. If endTime exists, we get posts before or equal to that time. If `rootOnly` is true, we only get root posts. By default, we get all post and replies.

Example:

HTTP GET `https://nouns.nymz.xyz/api/v1/posts?startTime=1687412894&endTime=1687474267293`
