### PR TITLE
Change title to Nouns Nymz everywhere

### DIFF
--- a/packages/frontend/src/components/global/Seo.tsx
+++ b/packages/frontend/src/components/global/Seo.tsx
@@ -7,7 +7,7 @@ interface SeoProps {
   ogDescription?: string;
 }
 
-export const TITLE = 'Noun Nyms';
+export const TITLE = 'Nouns Nymz';
 export const HOME_DESCRIPTION = 'Where the truth comes out';
 
 export function Seo(props: SeoProps) {

--- a/packages/frontend/src/lib/text.ts
+++ b/packages/frontend/src/lib/text.ts
@@ -148,14 +148,14 @@ export const error500 = {
   subtitle: 'Internal Server Error',
 };
 export const header = {
-  title: 'Noun Nyms',
+  title: 'Nouns Nymz',
   allUsers: 'All nyms',
   myIdentities: 'My identities',
   wallet: 'My wallet',
 };
 
 export const FAQ = {
-  title: 'Noun Nyms',
+  title: 'Nouns Nymz',
   body: "is a message board that allows persistent pseudonyms and pseudonymous discussions. Your identity here is a 'nym', which shows that you are a nouner but doesn't reveal your address. Check out our github for more details on how this works.",
 };
 


### PR DESCRIPTION
Open to feedback here, but a nouner made the point that it's probably worthwhile to have common naming for this thing across platforms. 

I.e. the url is nouns.nymz, but the title of the site is 'Noun nyms'. Figure it makes sense to standardize on the URL but curious wyt @grace-fagan 